### PR TITLE
Change arguments in StringTool.RemoveString to regex

### DIFF
--- a/ChuonJava/src/com/jimmiker/ChuonBinary.java
+++ b/ChuonJava/src/com/jimmiker/ChuonBinary.java
@@ -118,7 +118,7 @@ public class ChuonBinary {
         String typename = thing.getClass().getSimpleName();
         writer.writeByte((byte)(Arrays.asList(TypeFormat.type).indexOf(typename)));
         writer.write(GetBytesLength(Array.getLength(thing)));
-        typename = StringTool.RemoveString(typename,"[", "]");
+        typename = StringTool.RemoveString(typename,"\\[", "\\]");
         thing = TypeFormat.PrimitiveAndClassArray(thing);
         if (typename == "Byte")
         {
@@ -278,7 +278,7 @@ public class ChuonBinary {
     {
     	Object d = null;
         int count = GetIntLength(reader);
-        typ = StringTool.RemoveString(typ, "[", "]");
+        typ = StringTool.RemoveString(typ, "\\[", "\\]");
         if (typ == "Byte")
         {
             d = new byte[count];

--- a/ChuonJava/src/com/jimmiker/ChuonString.java
+++ b/ChuonJava/src/com/jimmiker/ChuonString.java
@@ -194,7 +194,7 @@ public class ChuonString {
     static Object StringToObjectForArray(String thing) throws Exception
     {
         String[] vs = StringTool.SplitWithFormat(thing, ':');
-        String typ =StringTool.RemoveString(vs[0], " ", "\n", "\r", "\t", "[", "]");
+        String typ =StringTool.RemoveString(vs[0], " ", "\n", "\r", "\t", "\\[", "\\]");
 
         String typenames = TypeFormat.ToJavaTrueTypeName(typ);
 
@@ -306,7 +306,7 @@ public class ChuonString {
     static Object StringToObjectForNotArray(String thing) throws Exception
     {
     	String[] vs = StringTool.SplitWithFormat(thing, ':');
-    	String typ = StringTool.RemoveString(vs[0], " ", "\n", "\r", "\t", "[", "]");
+    	String typ = StringTool.RemoveString(vs[0], " ", "\n", "\r", "\t", "\\[", "\\]");
 
     	String typenames = TypeFormat.ToJavaTrueTypeName(typ);
 


### PR DESCRIPTION
Since StringTool.RemoveString uses String.replaceAll, which requires its match string being a regex, pass in "[" will throw 
PatternSyntaxException.
We need to escape "[" and "]" to make the expression a legal regex.