### PR TITLE
Fix String comparison in Java

### DIFF
--- a/ChuonJava/src/com/jimmiker/ChuonBinary.java
+++ b/ChuonJava/src/com/jimmiker/ChuonBinary.java
@@ -120,34 +120,34 @@ public class ChuonBinary {
         writer.write(GetBytesLength(Array.getLength(thing)));
         typename = StringTool.RemoveString(typename,"\\[", "\\]");
         thing = TypeFormat.PrimitiveAndClassArray(thing);
-        if (typename == "Byte")
+        if (typename.equals("Byte"))
         {
             byte[] c = (byte[])thing;
             writer.write(c);
         }
-        else if(typename == "Character" || typename == "Boolean")
+        else if(typename.equals("Character") || typename.equals("Boolean"))
         {
         	Class nowtype = Class.forName("java.lang." + typename);
-        	Method bufferput = DataOutputStream.class.getMethod("write" + TypeFormat.type3[Arrays.asList(TypeFormat.type).indexOf(typename)], typename == "Character" ? int.class : boolean.class);
+        	Method bufferput = DataOutputStream.class.getMethod("write" + TypeFormat.type3[Arrays.asList(TypeFormat.type).indexOf(typename)], typename.equals("Character") ? int.class : boolean.class);
             for (int i = 0; i < Array.getLength(thing); i++)
             {
             	bufferput.invoke(writer, Array.get(thing, i));
             }
 		}
-        else if(typename == "Object" || typename == "Decimal" || typename == "String")
+        else if(typename.equals("Object") || typename.equals("Decimal") || typename.equals("String"))
         {
             for (int i = 0; i < Array.getLength(thing); i++)
             {
-                if (typename == "Object")
+                if (typename.equals("Object"))
                 {
                     writer.close();
                     Typing(stream, Array.get(thing, i));
                     writer = new DataOutputStream(stream);
                 }
-                else if (typename == "Decimal") {
+                else if (typename.equals("Decimal")) {
                 	writer.write(TypeFormat.ArrayReverse(((Decimal)Array.get(thing, i)).toByteArray()));
 				}
-                else if (typename == "String") 
+                else if (typename.equals("String"))
                 {
                 	byte[] nowdata = null;
                 	switch (typename) 
@@ -181,12 +181,12 @@ public class ChuonBinary {
     	DataOutputStream writer = new DataOutputStream(stream);
         writer.writeByte((byte)(Arrays.asList(TypeFormat.type).indexOf(typename)));
 
-        if (typename == "Byte" || typename == "Character" || typename == "Boolean")
+        if (typename.equals("Byte") || typename.equals("Character") || typename.equals("Boolean"))
         {
-        	Method bufferput = DataOutputStream.class.getMethod("write" + TypeFormat.type3[Arrays.asList(TypeFormat.type).indexOf(typename)], typename == "Byte" || typename == "Character" ? int.class : boolean.class);
+        	Method bufferput = DataOutputStream.class.getMethod("write" + TypeFormat.type3[Arrays.asList(TypeFormat.type).indexOf(typename)], typename.equals("Byte") || typename.equals("Character") ? int.class : boolean.class);
             bufferput.invoke(writer, thing);
         }
-        else if(typename == "String")
+        else if(typename.equals("String"))
         {
         	byte[] nowdata = null;
         	switch (typename) 
@@ -199,7 +199,7 @@ public class ChuonBinary {
 			}
     		writer.write(byteSerialize(nowdata));
         }
-        else if (typename == "Decimal") {
+        else if (typename.equals("Decimal")) {
         	writer.write(TypeFormat.ArrayReverse(((Decimal)thing).toByteArray()));
 		}
         else {
@@ -223,7 +223,7 @@ public class ChuonBinary {
         	{
         		TypingArray(stream, thing);
         	}
-        	else if (typename == "Map") {
+        	else if (typename.equals("Map")) {
                 Map c = (Map)thing;
                 Class datatype = thing.getClass();
                 Object[][] data = new Object[][] {c.keySet().toArray(), c.values().toArray()} ;
@@ -279,13 +279,13 @@ public class ChuonBinary {
     	Object d = null;
         int count = GetIntLength(reader);
         typ = StringTool.RemoveString(typ, "\\[", "\\]");
-        if (typ == "Byte")
+        if (typ.equals("Byte"))
         {
             d = new byte[count];
             reader.read((byte[])d, 0, ((byte[])d).length);
             return d;
         }
-        else if (typ == "Character" || typ == "Boolean") 
+        else if (typ.equals("Character") || typ.equals("Boolean"))
         {
         	Method bufferread = DataInputStream.class.getMethod("read" + TypeFormat.type3[Arrays.asList(TypeFormat.type).indexOf(typ)]);
             d = Array.newInstance(TypeFormat.TypeNameToType(typ), count);
@@ -294,22 +294,22 @@ public class ChuonBinary {
             	Array.set(d, i, bufferread.invoke(reader));
             }
         }
-        else if(typ == "Object" || typ == "Decimal" || typ == "String")
+        else if(typ.equals("Object") || typ.equals("Decimal") || typ.equals("String"))
         {
             d = Array.newInstance(TypeFormat.TypeNameToType(typ), count);
             for (int i = 0; i < count; i++)
             {
-                if (typ == "Object")
+                if (typ.equals("Object"))
                 {
 	            	Array.set(d, i, GetTyp(reader));
                 }
-                else if (typ == "Decimal")
+                else if (typ.equals("Decimal"))
                 {
                 	byte[] nowdata = new byte[16];
                 	reader.read(nowdata, 0, nowdata.length);
                 	Array.set(d, i, new Decimal(TypeFormat.ArrayReverse(nowdata)));
                 }
-                else if (typ == "String") 
+                else if (typ.equals("String"))
                 {
                 	int size = GetIntLength(reader);
                 	byte[] nowdata = new byte[size];
@@ -344,12 +344,12 @@ public class ChuonBinary {
     static Object GetTypNotArray(String typ, DataInputStream reader) throws Exception
     {
     	Object d = null;
-        if (typ == "Byte" || typ == "Character" || typ == "Boolean")
+        if (typ.equals("Byte") || typ.equals("Character") || typ.equals("Boolean"))
         {
         	Method bufferread = DataInputStream.class.getMethod("read" + TypeFormat.type3[Arrays.asList(TypeFormat.type).indexOf(typ)]);
             d = bufferread.invoke(reader);
         }
-        else if(typ == "String")
+        else if(typ.equals("String"))
         {
         	int size = GetIntLength(reader);
         	byte[] nowdata = new byte[size];
@@ -363,7 +363,7 @@ public class ChuonBinary {
 				}
 			}
         }
-        else if (typ == "Decimal") {
+        else if (typ.equals("Decimal")) {
         	byte[] nowdata = new byte[16];
         	reader.read(nowdata, 0, nowdata.length);
         	d = new Decimal(TypeFormat.ArrayReverse(nowdata));
@@ -393,7 +393,7 @@ public class ChuonBinary {
             {
                 get = GetTypArray(typ, reader);
             }
-            else if (typ == "Map")
+            else if (typ.equals("Map"))
             {
                 String[] typenames = new String[] { TypeFormat.type[reader.readByte()], TypeFormat.type[reader.readByte()] };
                 Map d = new HashMap();
@@ -406,7 +406,7 @@ public class ChuonBinary {
                 }
                 get = d;
             }
-            else if (typ == "null")
+            else if (typ.equals("null"))
             {
                 boolean a = reader.readBoolean();
                 get = null;

--- a/ChuonJava/src/com/jimmiker/ChuonString.java
+++ b/ChuonJava/src/com/jimmiker/ChuonString.java
@@ -64,7 +64,7 @@ public class ChuonString {
         if (Array.getLength(thing) > 0)
         {
             a += printTab(enter, cont) + "{" + printTab(enter, cont + 1);
-            if (type == "byte[]")
+            if (type.equals("byte[]"))
             {
                 a += StringTool.BytesToHex((byte[])thing) + printTab(enter, cont) + "}";
             }
@@ -81,15 +81,15 @@ public class ChuonString {
 				};
                 for (int i = 0; i < Array.getLength(thing) - 1; i++)
                 {
-                    if (type == "object[]")
+                    if (type.equals("object[]"))
                         a += ObjectToString(cont + 1, Array.get(thing, i), enter) + "," + printTab(enter, cont + 1);
                     else
-                        a += makestring.run(type == "char[]" ? "\'" : "\"", type == "char[]" || type == "string[]", i) + "," + printTab(enter, cont + 1);
+                        a += makestring.run(type.equals("char[]") ? "\'" : "\"", type.equals("char[]") || type.equals("string[]"), i) + "," + printTab(enter, cont + 1);
                 }
-                if (type == "object[]")
+                if (type.equals("object[]"))
                     a += ObjectToString(cont + 1, Array.get(thing, Array.getLength(thing) - 1), enter) + printTab(enter, cont) + "}";
                 else
-                    a += makestring.run(type == "char[]" ? "\'" : "\"", type == "char[]" || type == "string[]", Array.getLength(thing) - 1) + printTab(enter, cont) + "}";
+                    a += makestring.run(type.equals("char[]") ? "\'" : "\"", type.equals("char[]") || type.equals("string[]"), Array.getLength(thing) - 1) + printTab(enter, cont) + "}";
             }
         }
         else
@@ -113,7 +113,7 @@ public class ChuonString {
             {
                 a += ObjectToStringForArray(cont, thing, enter);
             }
-            else if (typ == "Dictionary")
+            else if (typ.equals("Dictionary"))
             {
                 Map c = (Map)thing;
                 Class datatype = thing.getClass();
@@ -167,7 +167,7 @@ public class ChuonString {
 	                        return nowthing.toString();
 					}
 				};
-                a += makestring.run(typ == "char" ? "\'" : "\"", typ == "char" || typ == "string");
+                a += makestring.run(typ.equals("char") ? "\'" : "\"", typ.equals("char") || typ.equals("string"));
             }
             else
             {
@@ -199,11 +199,11 @@ public class ChuonString {
         String typenames = TypeFormat.ToJavaTrueTypeName(typ);
 
         int found = thing.indexOf(':');
-        if (thing.substring(found + 1) != "NotThing")
+        if (!thing.substring(found + 1).equals("NotThing"))
         {
             String a = StringTool.TakeString(thing.substring(found + 1), '{', '}')[0];
 
-            if (typ == "byte")
+            if (typ.equals("byte"))
             {
                 a = a.replace(" ", "");
                 return StringTool.HexToBytes(a);
@@ -211,7 +211,7 @@ public class ChuonString {
             else
             {
                 String[] b = null;
-                if (typ == "object")
+                if (typ.equals("object"))
                 {
                     b = StringTool.TakeString(a, '{', '}');
                     for (int i = 0; i < b.length; i++)
@@ -236,7 +236,7 @@ public class ChuonString {
 
                 Object output;
                 
-                if (typ == "object")
+                if (typ.equals("object"))
                 {
                 	output = new Object[b.length];
                     for (int i = 0; i < b.length; i++)
@@ -366,7 +366,7 @@ public class ChuonString {
         {
             get = StringToObjectForArray(thing);
         }
-        else if (typ == "Dictionary")
+        else if (typ.equals("Dictionary"))
         {
             int found = thing.indexOf(':');
             String _data = StringTool.TakeString(thing.substring(found + 1), '{', '}')[0];
@@ -381,7 +381,7 @@ public class ChuonString {
             
             get = new HashMap();
 
-            if (data[2] != "NotThing")
+            if (!data[2].equals("NotThing"))
             {
                 String[] a = StringTool.TakeString(data[2], '{', '}');
 
@@ -407,7 +407,7 @@ public class ChuonString {
                 }
             }
         }
-        else if (typ == "null")
+        else if (typ.equals("null"))
         {
             get = null;
         }

--- a/ChuonJava/src/com/jimmiker/EncryptAndCompress.java
+++ b/ChuonJava/src/com/jimmiker/EncryptAndCompress.java
@@ -284,7 +284,7 @@ public class EncryptAndCompress
 			}
 		};
 
-        if (key != null && key != "")
+        if (key != null && !key.equals(""))
         {
             switch (_Lock)
             {

--- a/ChuonJava/src/com/jimmiker/StringTool.java
+++ b/ChuonJava/src/com/jimmiker/StringTool.java
@@ -67,7 +67,7 @@ public class StringTool {
         q.remove(q.size() - 1);
         for (int i = 0; i < q.size();)
         {
-            if (q.get(i) != "")
+            if (!q.get(i).equals(""))
             {
                 if (Matches(q.get(i), a) != Matches(q.get(i), b) + 1)
                 {

--- a/ChuonJava/src/com/jimmiker/TypeFormat.java
+++ b/ChuonJava/src/com/jimmiker/TypeFormat.java
@@ -39,7 +39,7 @@ class TypeFormat {
     public static String ToTrueTypeName(String type)
     {
         String typenames = type;
-        if (Arrays.asList(typelist2).indexOf(type) == -1 && type != "null")
+        if (Arrays.asList(typelist2).indexOf(type) == -1 && !type.equals("null"))
         {
             typenames = typelist2[Arrays.asList(typelist).indexOf(type)];
         }
@@ -49,7 +49,7 @@ class TypeFormat {
     public static String ToJavaTrueTypeName(String type)
     {
         String typenames = type;
-        if (Arrays.asList(typelist3).indexOf(type) == -1 && type != "null")
+        if (Arrays.asList(typelist3).indexOf(type) == -1 && !type.equals("null"))
         {
             typenames = typelist3[Arrays.asList(typelist).indexOf(type)];
         }
@@ -59,7 +59,7 @@ class TypeFormat {
     public static String ToJavaScannrTrueTypeName(String type)
     {
         String typenames = type;
-        if (Arrays.asList(typelist4).indexOf(type) == -1 && type != "null")
+        if (Arrays.asList(typelist4).indexOf(type) == -1 && !type.equals("null"))
         {
             typenames = typelist4[Arrays.asList(typelist).indexOf(type)];
         }
@@ -69,7 +69,7 @@ class TypeFormat {
     public static String ToSimpleTypeName(String type)
     {
         String typenames = type;
-        if (Arrays.asList(typelist).indexOf(type) == -1 && type != "null")
+        if (Arrays.asList(typelist).indexOf(type) == -1 && !type.equals("null"))
         {
             typenames = typelist[Arrays.asList(typelist2).indexOf(type)];
         }
@@ -78,7 +78,7 @@ class TypeFormat {
 
     public static Class TypeNameToType(String typename) throws ClassNotFoundException
     {
-        return Class.forName((typename == "Map" ? "java.util.Hash" : (typename == "Decimal" ? "com.jimmiker." : "java.lang.")) + typename);
+        return Class.forName((typename.equals("Map") ? "java.util.Hash" : (typename.equals("Decimal") ? "com.jimmiker." : "java.lang.")) + typename);
     }
 
 	public static Object PrimitiveAndClassArray(Object inputArray)
@@ -91,7 +91,7 @@ class TypeFormat {
     	Object output = inputArray;
     	if(ChangeType.containsKey(name))
     	{
-    		if(inputArray.getClass().getSimpleName().replace(name, "") == "[][]")
+    		if(inputArray.getClass().getSimpleName().replace(name, "").equals("[][]"))
     		{
     			name = name += "[]";
     		}


### PR DESCRIPTION
In Java, we cannot use == to compare two strings, it will give out false as long as they're two different string instances.
Replace == with String.equals() and != with !equals().

(Sorry for annoying PRs, I just want to make it work)